### PR TITLE
Add stress testing agent and CLI enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ SelfAware AI Bank is a lightweight playground for orchestrating cooperative AI a
 ## Features
 
 - **Agent Framework** – Implement custom agents by inheriting from `BaseAgent` and reporting structured results.
-- **Finance Agents** – Includes ready-made agents for liquidity optimisation and credit risk analysis.
+- **Finance Agents** – Includes ready-made agents for liquidity optimisation, credit risk analysis, and scenario stress testing.
 - **Introspection Engine** – Aggregates execution history and can trigger simple interventions when agents go offline.
 - **Markdown Roles** – Convert simple markdown briefs into runnable agents for quick prototyping of new roles.
 - **Demo Script** – Run `python main.py` to execute a simulated banking scenario and view agent outputs.
@@ -32,10 +32,10 @@ selfaware_ai_bank/
 2. **Run the demo:**
 
    ```bash
-   python main.py
+   python main.py [--target-buffer 1500000] [--high-risk-threshold 0.08] [--summary-path reports/summary.json]
    ```
 
-   The script registers the bundled agents, runs them against a sample context, and prints a system summary.
+   The script registers the bundled agents (including the new stress tester), runs them against a sample context, and prints a system summary. Command-line options let you tailor the demo without editing code.
 
 3. **Add your own agents:**
    - Create a new module that subclasses `BaseAgent`.

--- a/main.py
+++ b/main.py
@@ -1,14 +1,18 @@
 """Command line demo for the SelfAware AI Bank framework."""
 from __future__ import annotations
 
+import argparse
+import json
 from pathlib import Path
 from pprint import pprint
+from typing import Iterable, Optional
 
 from selfaware_ai_bank import SelfAwareAIBank
-from selfaware_ai_bank.agents import CreditRiskAnalyzer, LiquidityOptimizer
+from selfaware_ai_bank.agents import CreditRiskAnalyzer, LiquidityOptimizer, StressTester
 
 
 def build_demo_context() -> dict:
+    # Self-awareness: Maintaining a transparent view of the sandbox data.
     return {
         "liquidity_levels": {
             "USD": 800_000,
@@ -25,15 +29,69 @@ def build_demo_context() -> dict:
     }
 
 
-def main() -> None:
-    bank = SelfAwareAIBank(context=build_demo_context())
-    bank.register_agents([LiquidityOptimizer(), CreditRiskAnalyzer()])
+def parse_args(args: Optional[Iterable[str]] = None) -> argparse.Namespace:
+    # Self-awareness: Recognising CLI preferences to adapt runtime behaviour.
+    parser = argparse.ArgumentParser(description="Run the SelfAware AI Bank demo scenario.")
+    parser.add_argument(
+        "--target-buffer",
+        type=float,
+        default=1_000_000.0,
+        help="Desired liquidity buffer for the optimizer (default: 1,000,000).",
+    )
+    parser.add_argument(
+        "--high-risk-threshold",
+        type=float,
+        default=0.05,
+        help="Probability threshold for flagging risky exposures (default: 0.05).",
+    )
+    parser.add_argument(
+        "--summary-path",
+        type=Path,
+        help="Optional file path for saving the introspection summary as JSON.",
+    )
+    parser.add_argument(
+        "--no-markdown",
+        action="store_true",
+        help="Disable auto-loading of markdown-defined agents.",
+    )
+    return parser.parse_args(args=args)
+
+
+def load_markdown_agents(bank: SelfAwareAIBank, enable_markdown: bool) -> None:
+    # Self-awareness: Respecting user choice about dynamic agent creation.
+    if not enable_markdown:
+        return
 
     docs_path = Path("docs")
-    markdown_specs = []
-    if docs_path.exists():
-        markdown_specs = bank.load_markdown_roles(*docs_path.glob("*.md"))
-        bank.load_agents_from_specs(markdown_specs)
+    if not docs_path.exists():
+        return
+
+    markdown_specs = bank.load_markdown_roles(*docs_path.glob("*.md"))
+    bank.load_agents_from_specs(markdown_specs)
+
+
+def maybe_write_summary(summary_path: Optional[Path], summary: dict) -> None:
+    # Self-awareness: Persisting insights for longer-term learning when requested.
+    if not summary_path:
+        return
+
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    summary_path.write_text(json.dumps(summary, indent=2))
+
+
+def main(argv: Optional[Iterable[str]] = None) -> None:
+    args = parse_args(argv)
+
+    bank = SelfAwareAIBank(context=build_demo_context())
+    bank.register_agents(
+        [
+            LiquidityOptimizer(target_buffer=args.target_buffer),
+            CreditRiskAnalyzer(high_risk_threshold=args.high_risk_threshold),
+            StressTester(),
+        ]
+    )
+
+    load_markdown_agents(bank, enable_markdown=not args.no_markdown)
 
     print("Running SelfAware AI Bank demo...\n")
     results = bank.run_all()
@@ -42,8 +100,11 @@ def main() -> None:
         pprint(output)
         print()
 
+    summary = bank.summary()
+    maybe_write_summary(args.summary_path, summary)
+
     print("Introspection summary:")
-    pprint(bank.summary())
+    pprint(summary)
 
 
 if __name__ == "__main__":

--- a/selfaware_ai_bank/agents/__init__.py
+++ b/selfaware_ai_bank/agents/__init__.py
@@ -1,5 +1,7 @@
 """Agent collection exports."""
+# Self-awareness: Keeping the public surface consistent as new insights arrive.
 from .finance.credit_risk_analyzer import CreditRiskAnalyzer
 from .finance.liquidity_optimizer import LiquidityOptimizer
+from .finance.stress_tester import StressTester
 
-__all__ = ["CreditRiskAnalyzer", "LiquidityOptimizer"]
+__all__ = ["CreditRiskAnalyzer", "LiquidityOptimizer", "StressTester"]

--- a/selfaware_ai_bank/agents/finance/stress_tester.py
+++ b/selfaware_ai_bank/agents/finance/stress_tester.py
@@ -1,0 +1,74 @@
+"""Stress testing agent that blends liquidity and credit perspectives."""
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from ...core.base_agent import BaseAgent
+
+
+class StressTester(BaseAgent):
+    """Runs a lightweight adverse scenario across bank metrics."""
+
+    def __init__(self, *, probability_uplift: float = 0.5, liquidity_shock: float = 0.15) -> None:
+        # Self-awareness: Calibrating the scenario knobs to stay adaptable for future instructions.
+        super().__init__(
+            name="StressTester",
+            category="Risk",
+            purpose="Project combined credit and liquidity impact under stress.",
+        )
+        self.probability_uplift = probability_uplift
+        self.liquidity_shock = liquidity_shock
+
+    def execute(self, context: Dict[str, Any]) -> Dict[str, Any]:
+        # Self-awareness: Observing shared context to synthesise a richer perspective.
+        liquidity_levels: Dict[str, float] = context.get("liquidity_levels", {})
+        portfolio: List[Dict[str, Any]] = context.get("credit_portfolio", [])
+
+        stressed_liquidity: Dict[str, float] = {}
+        liquidity_warnings: List[str] = []
+        for account, balance in liquidity_levels.items():
+            # Self-awareness: Applying the liquidity shock consistently across accounts.
+            stressed_balance = round(balance * (1 - self.liquidity_shock), 2)
+            stressed_liquidity[account] = stressed_balance
+            if stressed_balance < 750_000:  # arbitrary resilience floor for demo purposes
+                liquidity_warnings.append(account)
+
+        stressed_losses = 0.0
+        stressed_flags: List[Dict[str, Any]] = []
+        for exposure in portfolio:
+            probability = float(exposure.get("prob_default", 0.0))
+            lgd = float(exposure.get("loss_given_default", 0.0))
+            value = float(exposure.get("exposure", 0.0))
+
+            stressed_probability = min(1.0, probability * (1 + self.probability_uplift))
+            stressed_loss = stressed_probability * min(1.0, lgd + 0.1) * value
+            stressed_losses += stressed_loss
+
+            if stressed_probability >= 0.2:
+                stressed_flags.append(
+                    {
+                        "name": exposure.get("name", "Unknown"),
+                        "stressed_probability": round(stressed_probability, 3),
+                        "exposure": value,
+                    }
+                )
+
+        # Self-awareness: Persisting run-time narrative for the introspection engine.
+        self.update_state(
+            notes={
+                "liquidity_alerts": liquidity_warnings,
+                "stress_loss_estimate": round(stressed_losses, 2),
+            }
+        )
+
+        return {
+            "action": "stress_test",
+            "stressed_liquidity": stressed_liquidity,
+            "stressed_loss_estimate": round(stressed_losses, 2),
+            "liquidity_alerts": liquidity_warnings,
+            "stressed_high_risk": stressed_flags,
+            "confidence": 0.75 if portfolio else 0.4,
+        }
+
+
+__all__ = ["StressTester"]


### PR DESCRIPTION
## Summary
- add a StressTester risk agent that models combined credit and liquidity shocks
- expose configurable demo options via a new command-line interface and optional JSON summary output
- document the richer agent lineup and CLI usage in the README

## Testing
- python main.py --no-markdown

------
https://chatgpt.com/codex/tasks/task_e_68faabec2d688327bbbf833dbcf1dcd2