### PR TITLE
Use timezone-aware UTC timestamps and add pytest.ini

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/selfaware_ai_bank/bank_orchestrator.py
+++ b/selfaware_ai_bank/bank_orchestrator.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Type
 
@@ -61,7 +61,7 @@ class SelfAwareAIBank:
     def run_agent(self, agent: BaseAgent) -> Dict[str, Any]:
         output = agent.execute(self.context)
         agent.update_state(notes={"last_output": output})
-        record = RunRecord(agent=agent.name, timestamp=datetime.utcnow(), output=output)
+        record = RunRecord(agent=agent.name, timestamp=datetime.now(timezone.utc), output=output)
         log_entry = {
             "agent": record.agent,
             "timestamp": record.timestamp.isoformat(),

--- a/selfaware_ai_bank/core/base_agent.py
+++ b/selfaware_ai_bank/core/base_agent.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, Optional
 
 
@@ -35,7 +35,7 @@ class BaseAgent(ABC):
             self.state.active = active
         if notes:
             self.state.notes.update(notes)
-        self.state.last_update = datetime.utcnow()
+        self.state.last_update = datetime.now(timezone.utc)
 
     def report_status(self) -> Dict[str, Any]:
         """Return a structured view that the introspection engine can consume."""


### PR DESCRIPTION
### Motivation
- Replace deprecated `datetime.utcnow()` calls with timezone-aware `datetime.now(timezone.utc)` to produce correct UTC timestamps and avoid deprecation warnings.
- Make running the test suite simpler by configuring `pytest` to include the repository root on `PYTHONPATH`.

### Description
- Updated `selfaware_ai_bank/core/base_agent.py` to import `timezone` and set `AgentState.last_update` with `datetime.now(timezone.utc)`.
- Updated `selfaware_ai_bank/bank_orchestrator.py` to import `timezone` and create `RunRecord` timestamps with `datetime.now(timezone.utc)`.
- Added a `pytest.ini` file with `pythonpath = .` so `pytest` works without manually setting `PYTHONPATH`.

### Testing
- Ran `pytest -q` and the test suite completed successfully with `7 passed`.
- The change addresses the prior deprecation warnings related to `utcnow()` by using timezone-aware timestamps.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698eba48f4688327bdd67025217ab2a4)