### PR TITLE
Add CYBER-OS v5 gameplay loop with active trace and SPA matrix UI

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 
 import argparse
 import json
+import random
 from pathlib import Path
 from pprint import pprint
 from typing import Iterable, Optional
 
 from selfaware_ai_bank import SelfAwareAIBank
 from selfaware_ai_bank.agents import CreditRiskAnalyzer, LiquidityOptimizer, StressTester
+from selfaware_ai_bank.cyber_os_v5 import MatrixServer, SYNONYM_GROUPS, SecureBankSystem, scan_network
 
 
 def build_demo_context() -> dict:
@@ -54,7 +56,60 @@ def parse_args(args: Optional[Iterable[str]] = None) -> argparse.Namespace:
         action="store_true",
         help="Disable auto-loading of markdown-defined agents.",
     )
+    parser.add_argument(
+        "--cyber-os",
+        action="store_true",
+        help="Run the interactive CYBER-OS v5.0 gameplay loop.",
+    )
     return parser.parse_args(args=args)
+
+
+def run_cyber_os() -> None:
+    bank = SecureBankSystem()
+    web = MatrixServer(bank)
+
+    print("CYBER-OS v5.0 booted. Type 'help' for commands.")
+    while True:
+        command = input("root@cyber-os:~# ").strip().lower()
+        if command == "help":
+            print("Modules: net-up, net-down, scan, bank, status, exit")
+        elif command == "net-up":
+            web.start()
+            print("Public Matrix Interface online on http://localhost:8080")
+        elif command == "net-down":
+            web.stop()
+            print("Public Matrix Interface taken offline.")
+        elif command == "scan":
+            print("Scanning 192.168.0.x subnet...")
+            for result in scan_network():
+                print(result)
+        elif command == "status":
+            print(f"ACTIVE NETWORK TRACE LEVEL: {bank.trace_level}%")
+            if bank.locked:
+                print("BLACK ICE ACTIVE: terminal is permanently locked.")
+        elif command == "bank":
+            concept = random.choice(list(SYNONYM_GROUPS.keys()))
+            print(f">> ICE ACTIVE: Semantic concept required '{concept}'")
+            user = input("User ID: ")
+            account = input("Account ID: ")
+            amount = int(input("Amount: ") or "0")
+            signature = input("Signature: ")
+            passphrase = input("Semantic Passphrase: ")
+            result = bank.request_withdrawal(
+                user=user,
+                account_id=account,
+                amount=amount,
+                signature=signature,
+                passphrase=passphrase,
+                required_concept=concept,
+            )
+            print(result)
+        elif command == "exit":
+            web.stop()
+            print("Terminating connection...")
+            return
+        else:
+            print("ERROR: Command not found. Type 'help'.")
 
 
 def load_markdown_agents(bank: SelfAwareAIBank, enable_markdown: bool) -> None:
@@ -81,6 +136,10 @@ def maybe_write_summary(summary_path: Optional[Path], summary: dict) -> None:
 
 def main(argv: Optional[Iterable[str]] = None) -> None:
     args = parse_args(argv)
+
+    if args.cyber_os:
+        run_cyber_os()
+        return
 
     bank = SelfAwareAIBank(context=build_demo_context())
     bank.register_agents(

--- a/selfaware_ai_bank/cyber_os_v5.py
+++ b/selfaware_ai_bank/cyber_os_v5.py
@@ -1,0 +1,272 @@
+"""CYBER-OS v5.0 inspired game loop with Active Trace and SPA Web-Matrix."""
+from __future__ import annotations
+
+import json
+import threading
+from dataclasses import dataclass, field
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Dict, List, Optional, Sequence, Tuple
+from urllib.parse import parse_qs, urlparse
+
+
+SYNONYM_GROUPS: Dict[str, List[str]] = {
+    "sentient_ai": [
+        "Sentient artificial intelligence",
+        "Artificial sentience",
+        "Conscious AI",
+        "Digital mind",
+        "Synthetic mind",
+    ],
+    "omniscience": ["Omniscient", "All-knowing", "Universal expert", "Polymath", "Erudite", "Encyclopedic knowledge"],
+    "stealth": ["Undetectable", "Cloaked", "Covert", "Ghosted", "Invisible", "Sub rosa", "Surreptitious"],
+    "cybernetics": ["Bionics", "Neural lace", "Wetware", "Cyber-implants", "Augmentation", "Biomechatronics"],
+}
+
+
+@dataclass
+class Account:
+    account_id: str
+    balance: int
+    authorized_users: Sequence[str]
+
+
+@dataclass
+class SecureBankSystem:
+    trace_level: int = 0
+    locked: bool = False
+    accounts: Dict[str, Account] = field(
+        default_factory=lambda: {
+            "fed_reserve_001": Account(
+                account_id="fed_reserve_001",
+                balance=10_000_000,
+                authorized_users=("admin_secure",),
+            )
+        }
+    )
+
+    def _normalize(self, value: str) -> str:
+        return value.strip().lower()
+
+    def _score(self, query: str, term: str) -> float:
+        q = self._normalize(query)
+        t = self._normalize(term)
+        shared = sum(1 for idx in range(min(len(q), len(t))) if q[idx] == t[idx])
+        return shared / max(len(q), len(t), 1)
+
+    def search_substring(self, query: str) -> List[Tuple[str, str, float]]:
+        q = self._normalize(query)
+        matches: List[Tuple[str, str, float]] = []
+        for group, terms in SYNONYM_GROUPS.items():
+            for term in terms:
+                if q in self._normalize(term):
+                    matches.append((group, term, 1.0))
+        return matches
+
+    def search_fuzzy(self, query: str, *, limit: int = 10, min_score: float = 0.3) -> List[Tuple[str, str, float]]:
+        matches: List[Tuple[str, str, float]] = []
+        for group, terms in SYNONYM_GROUPS.items():
+            for term in terms:
+                score = self._score(query, term)
+                if score >= min_score:
+                    matches.append((group, term, round(score, 2)))
+        matches.sort(key=lambda item: item[2], reverse=True)
+        return matches[:limit]
+
+    def is_synonym(self, value: str, group: str) -> bool:
+        terms = SYNONYM_GROUPS.get(group, [])
+        return self._normalize(value) in {self._normalize(term) for term in terms}
+
+    def request_withdrawal(
+        self,
+        *,
+        user: str,
+        account_id: str,
+        amount: int,
+        signature: str,
+        passphrase: str,
+        required_concept: str,
+    ) -> str:
+        if self.locked:
+            return "FATAL: BLACK ICE already deployed. Access permanently revoked."
+
+        account = self.accounts.get(account_id)
+
+        reason: Optional[str] = None
+        if amount <= 0:
+            reason = "Invalid integer payload. Buffer overflow mitigated."
+        elif account is None:
+            reason = "Target node offline."
+        elif user not in account.authorized_users:
+            reason = "Invalid User Credentials."
+        elif signature != "valid_sig":
+            reason = "Invalid Cryptographic Signature."
+        elif not self.is_synonym(passphrase, required_concept):
+            reason = f"Semantic check failed for: {required_concept}"
+        elif account.balance < amount:
+            reason = "Insufficient network liquidity."
+
+        if reason:
+            self.trace_level += 35
+            if self.trace_level >= 100:
+                self.trace_level = 100
+                self.locked = True
+                return f"ACCESS DENIED: {reason} | CRITICAL: TRACE 100%. BLACK ICE DEPLOYED."
+            return f"ACCESS DENIED: {reason} | Trace level {self.trace_level}%"
+
+        account.balance -= amount
+        self.trace_level = max(0, self.trace_level - 20)
+        return f"TRANSACTION APPROVED. FUNDS DISBURSED. Remaining balance: ${account.balance:,}."
+
+
+class _CyberRequestHandler(BaseHTTPRequestHandler):
+    bank: SecureBankSystem
+
+    def _write(self, payload: str, status: HTTPStatus = HTTPStatus.OK, content_type: str = "text/html") -> None:
+        body = payload.encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", f"{content_type}; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format: str, *args) -> None:  # noqa: A003
+        return
+
+    def do_GET(self) -> None:  # noqa: N802
+        parsed = urlparse(self.path)
+        if parsed.path == "/":
+            self._write(_spa_html(), content_type="text/html")
+            return
+
+        if parsed.path not in {"/api/search", "/api/fuzzy"}:
+            self._write("Not found", status=HTTPStatus.NOT_FOUND, content_type="text/plain")
+            return
+
+        params = parse_qs(parsed.query)
+        query = (params.get("q", [""])[0]).strip()
+        if parsed.path == "/api/search":
+            data = self.bank.search_substring(query)
+        else:
+            data = self.bank.search_fuzzy(query)
+
+        payload = [
+            {"group": group, "term": term, "score": score}
+            for group, term, score in data
+        ]
+        self._write(json.dumps(payload), content_type="application/json")
+
+
+class MatrixServer:
+    def __init__(self, bank: SecureBankSystem, host: str = "0.0.0.0", port: int = 8080) -> None:
+        self.bank = bank
+        self.host = host
+        self.port = port
+        self._server: Optional[ThreadingHTTPServer] = None
+        self._thread: Optional[threading.Thread] = None
+
+    @property
+    def running(self) -> bool:
+        return self._server is not None
+
+    def start(self) -> None:
+        if self.running:
+            return
+
+        handler = type("CyberRequestHandler", (_CyberRequestHandler,), {})
+        handler.bank = self.bank
+        self._server = ThreadingHTTPServer((self.host, self.port), handler)
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        if not self._server:
+            return
+        self._server.shutdown()
+        self._server.server_close()
+        self._server = None
+        self._thread = None
+
+
+def scan_network() -> List[str]:
+    return [
+        "Node discovered: MATRIX_WEB [Localhost:8080]",
+        "Node discovered: FED_RESERVE_MAINFRAME [ID: fed_reserve_001]",
+    ]
+
+
+def _spa_html() -> str:
+    return """<!DOCTYPE html>
+<html>
+<head>
+  <meta charset='UTF-8' />
+  <meta name='viewport' content='width=device-width, initial-scale=1.0' />
+  <title>SYS@LEXICON // Matrix Node</title>
+  <style>
+    body {
+      background-color: #050505;
+      color: #00ff00;
+      font-family: 'Courier New', Courier, monospace;
+      margin: 20px;
+      background-image: repeating-linear-gradient(0deg, transparent, transparent 2px, rgba(0, 255, 0, 0.06) 2px, rgba(0, 255, 0, 0.06) 4px);
+    }
+    .container { display: flex; gap: 20px; max-width: 1200px; margin: 0 auto; }
+    .panel { border: 1px solid #00ff00; padding: 20px; box-shadow: 0 0 10px #00ff00; background: #0a0a0a; flex: 1; }
+    h2 { color: #ff00ff; text-shadow: 0 0 10px #ff00ff; border-bottom: 1px solid #ff00ff; padding-bottom: 10px; margin-top: 0; }
+    input[type=text] { background: #000; color: #00ff00; border: 1px solid #00ff00; padding: 10px; width: calc(100% - 110px); }
+    button { background: #00ff00; color: #000; border: none; padding: 10px; width: 90px; cursor: pointer; font-weight: bold; }
+    button:hover { background: #ff00ff; color: #fff; box-shadow: 0 0 10px #ff00ff; }
+    .form-group { margin-bottom: 25px; }
+    .label { color: #00ffff; margin-bottom: 5px; display: block; font-weight: bold; }
+    #output { background: #001100; padding: 15px; border: 1px dashed #00ff00; min-height: 300px; white-space: pre-wrap; }
+  </style>
+</head>
+<body>
+  <div class='container'>
+    <div class='panel'>
+      <h2>// NEURAL KNOWLEDGE GRAPH API</h2>
+      <div class='form-group'>
+        <span class='label'>// EXACT MATCH (/api/search)</span>
+        <input type='text' id='search-input' placeholder='Enter search vector...' />
+        <button onclick="fetchData('search')">SEARCH</button>
+      </div>
+      <div class='form-group'>
+        <span class='label'>// AI FUZZY SEMANTIC MATCH (/api/fuzzy)</span>
+        <input type='text' id='fuzzy-input' placeholder='Enter corrupted string...' />
+        <button onclick="fetchData('fuzzy')">ANALYZE</button>
+      </div>
+    </div>
+    <div class='panel' style='flex: 1.5;'>
+      <h2>// TERMINAL OUTPUT STREAM</h2>
+      <div id='output'>Awaiting query payload...</div>
+    </div>
+  </div>
+  <script>
+    async function typeOut(target, text) {
+      target.textContent = '';
+      for (const char of text) {
+        target.textContent += char;
+        await new Promise(resolve => setTimeout(resolve, 6));
+      }
+    }
+
+    async function fetchData(endpoint) {
+      const query = document.getElementById(endpoint + '-input').value;
+      const out = document.getElementById('output');
+      out.innerHTML = '<span style="color:#ffff00">>> DECRYPTING PACKETS...</span>';
+      try {
+        const res = await fetch(`/api/${endpoint}?q=${encodeURIComponent(query)}`);
+        const data = await res.json();
+        if (data.length === 0) {
+          out.innerHTML = '<span style="color:#ff0000">[ERROR] 0 NODES FOUND.</span>';
+        } else {
+          out.innerHTML = '';
+          await typeOut(out, '[SUCCESS] PAYLOAD DECRYPTED:\n\n' + JSON.stringify(data, null, 2));
+        }
+      } catch (e) {
+        out.innerHTML = '<span style="color:#ff0000">[CRITICAL] CONNECTION TO MATRIX LOST.</span>';
+      }
+    }
+  </script>
+</body>
+</html>"""

--- a/tests/test_cyber_os_v5.py
+++ b/tests/test_cyber_os_v5.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import json
+from urllib.request import urlopen
+
+from selfaware_ai_bank.cyber_os_v5 import MatrixServer, SecureBankSystem, scan_network
+
+
+def test_scan_network_lists_expected_nodes() -> None:
+    nodes = scan_network()
+    assert any("MATRIX_WEB" in node for node in nodes)
+    assert any("FED_RESERVE_MAINFRAME" in node for node in nodes)
+
+
+def test_trace_level_and_lockout_progression() -> None:
+    bank = SecureBankSystem()
+
+    denied = bank.request_withdrawal(
+        user="intruder",
+        account_id="fed_reserve_001",
+        amount=100,
+        signature="bad_sig",
+        passphrase="invalid",
+        required_concept="stealth",
+    )
+    assert "ACCESS DENIED" in denied
+    assert bank.trace_level == 35
+    assert bank.locked is False
+
+    bank.request_withdrawal(
+        user="intruder",
+        account_id="fed_reserve_001",
+        amount=100,
+        signature="bad_sig",
+        passphrase="invalid",
+        required_concept="stealth",
+    )
+    denied = bank.request_withdrawal(
+        user="intruder",
+        account_id="fed_reserve_001",
+        amount=100,
+        signature="bad_sig",
+        passphrase="invalid",
+        required_concept="stealth",
+    )
+    assert "BLACK ICE DEPLOYED" in denied
+    assert bank.trace_level == 100
+    assert bank.locked is True
+
+
+def test_successful_withdrawal_reduces_trace() -> None:
+    bank = SecureBankSystem(trace_level=40)
+    approved = bank.request_withdrawal(
+        user="admin_secure",
+        account_id="fed_reserve_001",
+        amount=500,
+        signature="valid_sig",
+        passphrase="covert",
+        required_concept="stealth",
+    )
+    assert "TRANSACTION APPROVED" in approved
+    assert bank.trace_level == 20
+
+
+def test_api_endpoints() -> None:
+    bank = SecureBankSystem()
+    server = MatrixServer(bank, port=8091)
+    server.start()
+    try:
+        with urlopen("http://127.0.0.1:8091/api/search?q=covert", timeout=5) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+        assert payload
+        assert payload[0]["group"] == "stealth"
+
+        with urlopen("http://127.0.0.1:8091/", timeout=5) as response:
+            page = response.read().decode("utf-8")
+        assert "TERMINAL OUTPUT STREAM" in page
+    finally:
+        server.stop()


### PR DESCRIPTION
### Motivation
- Provide a playable CYBER-OS v5.0 surface that demonstrates an active-trace banking flow, a Single-Page Application matrix UI served from the app, and simple network reconnaissance for a demo/game loop. 
- Integrate the new gameplay surface into the project CLI so developers can run the matrix server and interactive loop directly from `main.py`.

### Description
- Add `selfaware_ai_bank/cyber_os_v5.py` which implements a `SecureBankSystem` with trace escalation and Black ICE lockout logic, synonym/fuzzy search utilities, a `MatrixServer` (threaded HTTP server) and an embedded SPA HTML UI served by `_spa_html()` exposing `/`, `/api/search`, and `/api/fuzzy` endpoints. 
- Extend `main.py` to expose a `--cyber-os` mode and an interactive `run_cyber_os()` REPL with commands `net-up`, `net-down`, `scan`, `bank`, `status`, and `exit`. 
- Add `tests/test_cyber_os_v5.py` to validate network scan output, trace escalation and lockout progression, successful withdrawal trace reduction, and API/SPA endpoint responses. 
- Wire SPA behavior to use `fetch()` and a small typewriter renderer so JSON payloads returned by the Lisp-inspired backend are typed into the terminal panel in the browser.

### Testing
- Ran the full test suite with `pytest -q` and all tests passed (`11 passed`).
- Verified CLI usage with `python main.py --help` which lists the new `--cyber-os` flag. 
- Performed a runtime smoke check of the bank flow by invoking `SecureBankSystem.request_withdrawal` which produced an approved transaction and expected trace reduction. 
- Attempted an automated Playwright-based SPA screenshot run but the browser tool environment could not import the local package (`ModuleNotFoundError: selfaware_ai_bank`), so the visual verification did not complete in that environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699aab53e308832795e62964b5fa0d83)