### PR TITLE
Add Common Lisp quantum-super-ai simulation (quantum_ai.lisp) and README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,15 @@ docs/
 
    - Running `main.py` will automatically load these definitions and turn them into runnable agents.
 
+
+4. **Run the Common Lisp quantum simulation (optional):**
+
+   ```bash
+   sbcl --script quantum_ai.lisp
+   ```
+
+   This script runs three full cognition/financial cycles using the `quantum-super-ai` package.
+
 ## Next Steps
 
 Ideas for expanding the playground:

--- a/quantum_ai.lisp
+++ b/quantum_ai.lisp
@@ -1,0 +1,158 @@
+(defpackage :quantum-super-ai
+  (:use :cl)
+  (:export :run-cycle
+           :make-quantum-super-ai))
+
+(in-package :quantum-super-ai)
+
+(defstruct (quantum-super-ai
+            (:constructor %make-quantum-super-ai))
+  memory
+  knowledge-base
+  performance-log
+  state-space
+  learning-rate
+  iteration
+  swift-fiat-balance
+  crypto-balance
+  swift-code
+  crypto-wallet-address)
+
+(defun sha256 (input)
+  "Simulates SHA256 hashing by shelling out to shasum (SBCL)."
+  (let ((process
+          (sb-ext:run-program
+           "shasum"
+           '("-a" "256")
+           :input (make-string-input-stream input)
+           :output :stream)))
+    (unwind-protect
+         (let ((line (read-line (sb-ext:process-output process) nil "")))
+           (subseq line 0 64))
+      (close (sb-ext:process-output process)))))
+
+(defun make-quantum-super-ai ()
+  (%make-quantum-super-ai
+   :memory '()
+   :knowledge-base (make-hash-table)
+   :performance-log '()
+   :state-space (loop repeat 10 collect (random 1.0))
+   :learning-rate 0.1
+   :iteration 0
+   :swift-fiat-balance (+ (* (random 1.0) 8.4e12) 1.5e12)
+   :crypto-balance (+ (* (random 1.0) 3.0e12) 2.0e12)
+   :swift-code "AIFEDUS33XXX"
+   :crypto-wallet-address (subseq (sha256 (write-to-string (random 256))) 0 40)))
+
+(defun swift-federal-reserve-network (quantum-super-ai)
+  (let ((yield-amount (+ (* (random 1.0) 4.0e8) 1.0e8)))
+    (setf (quantum-super-ai-swift-fiat-balance quantum-super-ai)
+          (+ yield-amount (quantum-super-ai-swift-fiat-balance quantum-super-ai)))
+    (list :network "FEDERAL_RESERVE_SWIFT"
+          :routing-node (quantum-super-ai-swift-code quantum-super-ai)
+          :status "SECURE_CONNECTION_ACTIVE"
+          :balance (format nil "$~,.2f" (quantum-super-ai-swift-fiat-balance quantum-super-ai))
+          :recent-yield (format nil "+$~,.2f" yield-amount))))
+
+(defun crypto-wallet-manager (quantum-super-ai)
+  (let ((fluctuation (+ (* (random 1.0) 0.07) -0.02)))
+    (setf (quantum-super-ai-crypto-balance quantum-super-ai)
+          (* (quantum-super-ai-crypto-balance quantum-super-ai) (+ 1 fluctuation)))
+    (list :network "QUANTUM_BLOCKCHAIN"
+          :wallet-address (quantum-super-ai-crypto-wallet-address quantum-super-ai)
+          :balance-usd-value (format nil "$~,.2f" (quantum-super-ai-crypto-balance quantum-super-ai))
+          :market-shift (format nil "~:+.2f%%" (* 100 fluctuation)))))
+
+(defun generate-luhn-valid-card (&optional (prefix "4"))
+  "Generates a Luhn-valid 16-digit card number."
+  (let ((card (loop for i from 1 to 15
+                    collect (if (= i 1) (parse-integer prefix) (random 10)))))
+    (let ((sum 0))
+      (dotimes (i (length card) sum)
+        (let ((digit (nth i (reverse card))))
+          (if (evenp i)
+              (let ((doubled (* 2 digit)))
+                (setf sum (+ sum (if (> doubled 9) (- doubled 9) doubled))))
+              (setf sum (+ sum digit)))))
+      (let* ((check-digit (mod (- 10 (mod sum 10)) 10))
+             (full-card (append card (list check-digit)))
+             (card-str (format nil "~{~A~}" full-card)))
+        (format nil "~a ~a ~a ~a"
+                (subseq card-str 0 4)
+                (subseq card-str 4 8)
+                (subseq card-str 8 12)
+                (subseq card-str 12 16))))))
+
+(defun quantum-ai (inputs)
+  (let ((weighted-sum (reduce #'+ (mapcar (lambda (i) (* i (random 1.0))) inputs))))
+    (tanh weighted-sum)))
+
+(defun quantum-neural-system (states)
+  (mapcar (lambda (s) (sin (* s (random 1.0)))) states))
+
+(defun quantum-learning-machine (quantum-super-ai)
+  (setf (quantum-super-ai-state-space quantum-super-ai)
+        (mapcar (lambda (s)
+                  (+ s (* (- (random 1.0) 0.5)
+                          (quantum-super-ai-learning-rate quantum-super-ai))))
+                (quantum-super-ai-state-space quantum-super-ai))))
+
+(defun quantum-optimization (quantum-super-ai)
+  (reduce #'max (quantum-super-ai-state-space quantum-super-ai)))
+
+(defun agi-core-system (quantum-super-ai input-data)
+  (push (format nil "Processed: ~a" input-data) (quantum-super-ai-memory quantum-super-ai))
+  (format nil "Processed: ~a" input-data))
+
+(defun recursive-cognitive-architecture (quantum-super-ai)
+  (setf (quantum-super-ai-learning-rate quantum-super-ai)
+        (* (quantum-super-ai-learning-rate quantum-super-ai) 0.99))
+  (incf (quantum-super-ai-iteration quantum-super-ai)))
+
+(defun predictive-intelligence-framework (quantum-super-ai)
+  (let ((sum (reduce #'+ (quantum-super-ai-state-space quantum-super-ai))))
+    (* sum (+ 0.8 (random 0.4)))))
+
+(defun meta-intelligence-system (quantum-super-ai)
+  (let ((score (reduce #'+ (quantum-super-ai-state-space quantum-super-ai))))
+    (push score (quantum-super-ai-performance-log quantum-super-ai))
+    score))
+
+(defun run-cycle (quantum-super-ai input-data)
+  (format t "~%=============================================")
+  (format t "~%  AI SYSTEM & FINANCIAL CYCLE START")
+  (format t "~%=============================================")
+
+  (format t "~%[COGNITION]")
+  (format t "~% -> ~a" (agi-core-system quantum-super-ai input-data))
+
+  (let ((q-states (quantum-neural-system (quantum-super-ai-state-space quantum-super-ai))))
+    (format t "~% -> Quantum Decision Value: ~a" (round (quantum-ai q-states)))
+    (format t "~% -> Predictive State Forecast: ~a" (round (predictive-intelligence-framework quantum-super-ai))))
+
+  (format t "~%~%[FINANCIAL NETWORK]")
+  (let ((swift-data (swift-federal-reserve-network quantum-super-ai)))
+    (format t "~% -> SWIFT Fed Balance:  ~a (~a)" (getf swift-data :balance) (getf swift-data :recent-yield))
+    (format t "~% -> SWIFT Routing:      ~a | ~a" (getf swift-data :routing-node) (getf swift-data :status)))
+
+  (let ((crypto-data (crypto-wallet-manager quantum-super-ai)))
+    (format t "~% -> Crypto Wallet:      ~a...~a" (subseq (getf crypto-data :wallet-address) 0 12)
+            (subseq (getf crypto-data :wallet-address)
+                    (- (length (getf crypto-data :wallet-address)) 4)))
+    (format t "~% -> Crypto Balance:     ~a [Shift: ~a]" (getf crypto-data :balance-usd-value) (getf crypto-data :market-shift)))
+
+  (let ((card (generate-luhn-valid-card "4")))
+    (format t "~% -> Generated Auth Card: ~a (Luhn Valid)" card))
+
+  (quantum-learning-machine quantum-super-ai)
+  (recursive-cognitive-architecture quantum-super-ai)
+  (format t "~% -> Optimal Quantum State: ~,4f" (quantum-optimization quantum-super-ai))
+  (let ((score (meta-intelligence-system quantum-super-ai)))
+    (format t "~%~%[SYSTEM DIAGNOSTICS]")
+    (format t "~% -> Cycle Optimization Score: ~a" (round score)))
+
+  (format t "~%=============================================~%"))
+
+(let ((ai (make-quantum-super-ai)))
+  (dotimes (i 3)
+    (run-cycle ai (format nil "Executing Global Financial & Data Sweep #~d" (1+ i)))))


### PR DESCRIPTION
### Motivation
- Provide a complete Common Lisp implementation of the `quantum-super-ai` simulation so the repository can demonstrate the user-provided quantum/financial AI example.
- Ensure the Lisp code is standard-compliant by fixing unbounded `random` calls and a list-to-string conversion in the Luhn card generator.
- Make the project README include optional instructions to run the Lisp simulation with SBCL.

### Description
- Added `quantum_ai.lisp`, which defines the `:quantum-super-ai` package, a `quantum-super-ai` struct, a `%make-quantum-super-ai` constructor wrapper, and a `make-quantum-super-ai` factory that initializes state and balances with bounded `random` calls.
- Implemented `sha256` via `sb-ext:run-program` calling `shasum -a 256`, and integrated it to generate a crypto wallet address substring, with careful process output handling.
- Implemented cognition and finance functions including `swift-federal-reserve-network`, `crypto-wallet-manager`, `quantum-ai`, `quantum-neural-system`, learning/optimization helpers, `generate-luhn-valid-card` with safe list-to-string formatting, and `run-cycle` with a 3-iteration runner block.
- Updated `README.md` to include optional usage instructions for running the Lisp script with `sbcl --script quantum_ai.lisp`.

### Testing
- Ran the Python test suite with `pytest -q`, and all tests passed: `11 passed`.
- Attempted to execute the Lisp script with `sbcl --script quantum_ai.lisp` in this environment, but the command failed because `sbcl` is not installed here (execution unavailable).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5bd898fdc832797b36b9fe1f705a2)