### PR TITLE
Add V3 Quantum-Entropic Strategist (`quantum-strat`) and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ docs/
    sbcl --script quantum_ai.lisp
    ```
 
-   This script runs three full cognition/financial cycles using the `quantum-super-ai` package.
+   This script runs three full cognition/financial cycles using the `quantum-strat` package and the V3 entropic strategist loop.
 
 ## Next Steps
 

--- a/quantum_ai.lisp
+++ b/quantum_ai.lisp
@@ -1,158 +1,191 @@
-(defpackage :quantum-super-ai
+;; ======================================================================
+;; COGNITIVE LAYER V3: QUANTUM-ENTROPIC STRATEGIST (COMPLETE)
+;; UPGRADES: CLOS Architecture, Wave-Function Collapse, Entropic Scaling
+;; ======================================================================
+
+(defpackage :quantum-strat
   (:use :cl)
-  (:export :run-cycle
-           :make-quantum-super-ai))
+  (:export :initialize-system :run-quantum-cycle :generate-quantum-key))
 
-(in-package :quantum-super-ai)
+(in-package :quantum-strat)
 
-(defstruct (quantum-super-ai
-            (:constructor %make-quantum-super-ai))
-  memory
-  knowledge-base
-  performance-log
-  state-space
-  learning-rate
-  iteration
-  swift-fiat-balance
-  crypto-balance
-  swift-code
-  crypto-wallet-address)
+;; --- 1. CLOS DEFINITIONS (STATE ENCAPSULATION) ---
 
-(defun sha256 (input)
-  "Simulates SHA256 hashing by shelling out to shasum (SBCL)."
-  (let ((process
-          (sb-ext:run-program
-           "shasum"
-           '("-a" "256")
-           :input (make-string-input-stream input)
-           :output :stream)))
-    (unwind-protect
-         (let ((line (read-line (sb-ext:process-output process) nil "")))
-           (subseq line 0 64))
-      (close (sb-ext:process-output process)))))
+(defclass cognitive-core ()
+  ((epoch :initform 0 :accessor epoch)
+   (learning-rate :initform 0.08 :accessor learning-rate)
+   (neural-weights :initform '(0.24 0.78 0.52) :accessor neural-weights)
+   (knowledge-base :initarg :kb :accessor kb)))
 
-(defun make-quantum-super-ai ()
-  (%make-quantum-super-ai
-   :memory '()
-   :knowledge-base (make-hash-table)
-   :performance-log '()
-   :state-space (loop repeat 10 collect (random 1.0))
-   :learning-rate 0.1
-   :iteration 0
-   :swift-fiat-balance (+ (* (random 1.0) 8.4e12) 1.5e12)
-   :crypto-balance (+ (* (random 1.0) 3.0e12) 2.0e12)
-   :swift-code "AIFEDUS33XXX"
-   :crypto-wallet-address (subseq (sha256 (write-to-string (random 256))) 0 40)))
+(defclass portfolio ()
+  ((balance :initform 1.15e77 :accessor balance)
+   (positions :initform nil :accessor positions)
+   (risk-coeff :initform 0.01 :accessor risk-coeff)))
 
-(defun swift-federal-reserve-network (quantum-super-ai)
-  (let ((yield-amount (+ (* (random 1.0) 4.0e8) 1.0e8)))
-    (setf (quantum-super-ai-swift-fiat-balance quantum-super-ai)
-          (+ yield-amount (quantum-super-ai-swift-fiat-balance quantum-super-ai)))
-    (list :network "FEDERAL_RESERVE_SWIFT"
-          :routing-node (quantum-super-ai-swift-code quantum-super-ai)
-          :status "SECURE_CONNECTION_ACTIVE"
-          :balance (format nil "$~,.2f" (quantum-super-ai-swift-fiat-balance quantum-super-ai))
-          :recent-yield (format nil "+$~,.2f" yield-amount))))
+(defclass market-state ()
+  ((entropy :initform 0.1 :accessor entropy)
+   (signal-vector :initform '(0.0 0.0 0.0) :accessor signal-vector)))
 
-(defun crypto-wallet-manager (quantum-super-ai)
-  (let ((fluctuation (+ (* (random 1.0) 0.07) -0.02)))
-    (setf (quantum-super-ai-crypto-balance quantum-super-ai)
-          (* (quantum-super-ai-crypto-balance quantum-super-ai) (+ 1 fluctuation)))
-    (list :network "QUANTUM_BLOCKCHAIN"
-          :wallet-address (quantum-super-ai-crypto-wallet-address quantum-super-ai)
-          :balance-usd-value (format nil "$~,.2f" (quantum-super-ai-crypto-balance quantum-super-ai))
-          :market-shift (format nil "~:+.2f%%" (* 100 fluctuation)))))
+(defclass session ()
+  ((api-key :initarg :key :accessor api-key)
+   (auth-level :initform :omega-tier :accessor auth-level)))
 
-(defun generate-luhn-valid-card (&optional (prefix "4"))
-  "Generates a Luhn-valid 16-digit card number."
-  (let ((card (loop for i from 1 to 15
-                    collect (if (= i 1) (parse-integer prefix) (random 10)))))
-    (let ((sum 0))
-      (dotimes (i (length card) sum)
-        (let ((digit (nth i (reverse card))))
-          (if (evenp i)
-              (let ((doubled (* 2 digit)))
-                (setf sum (+ sum (if (> doubled 9) (- doubled 9) doubled))))
-              (setf sum (+ sum digit)))))
-      (let* ((check-digit (mod (- 10 (mod sum 10)) 10))
-             (full-card (append card (list check-digit)))
-             (card-str (format nil "~{~A~}" full-card)))
-        (format nil "~a ~a ~a ~a"
-                (subseq card-str 0 4)
-                (subseq card-str 4 8)
-                (subseq card-str 8 12)
-                (subseq card-str 12 16))))))
+;; --- 2. GLOBAL ENVIRONMENT ---
 
-(defun quantum-ai (inputs)
-  (let ((weighted-sum (reduce #'+ (mapcar (lambda (i) (* i (random 1.0))) inputs))))
-    (tanh weighted-sum)))
+(defvar *core* nil)
+(defvar *port* nil)
+(defvar *market* nil)
+(defvar *session* nil)
+(defvar *api-registry* (make-hash-table :test 'equal))
 
-(defun quantum-neural-system (states)
-  (mapcar (lambda (s) (sin (* s (random 1.0)))) states))
+(defun initialize-system ()
+  "Bootstraps the V3 CLOS environment."
+  (setf *core* (make-instance 'cognitive-core
+                              :kb '((:id 1 :concept "Momentum"       :vector (0.8 0.2 0.1))
+                                    (:id 2 :concept "Mean Reversion" :vector (0.1 0.9 0.2))
+                                    (:id 3 :concept "Risk Parity"    :vector (0.3 0.3 0.9))
+                                    (:id 4 :concept "LLM-Sentiment"  :vector (0.5 0.5 0.5))
+                                    (:id 5 :concept "Black Swan"     :vector (0.9 0.1 0.8)))))
+  (setf *port* (make-instance 'portfolio))
+  (setf *market* (make-instance 'market-state))
+  (format t "[SYSTEM] V3 Quantum-Entropic Core Initialized.~%"))
 
-(defun quantum-learning-machine (quantum-super-ai)
-  (setf (quantum-super-ai-state-space quantum-super-ai)
-        (mapcar (lambda (s)
-                  (+ s (* (- (random 1.0) 0.5)
-                          (quantum-super-ai-learning-rate quantum-super-ai))))
-                (quantum-super-ai-state-space quantum-super-ai))))
+;; --- 3. AUTHENTICATION & LIQUIDITY ---
 
-(defun quantum-optimization (quantum-super-ai)
-  (reduce #'max (quantum-super-ai-state-space quantum-super-ai)))
+(defun generate-quantum-key (user-id)
+  "Generates an entangled API Key."
+  (let ((key (format nil "INF-Q-~A-~X" user-id (random 1000000000))))
+    (setf (gethash key *api-registry*) t)
+    (format t "[AUTH] Quantum Key Forged: ~A~%" key)
+    key))
 
-(defun agi-core-system (quantum-super-ai input-data)
-  (push (format nil "Processed: ~a" input-data) (quantum-super-ai-memory quantum-super-ai))
-  (format nil "Processed: ~a" input-data))
+(defun authenticate (key)
+  "Validates key presence before wave-function collapse."
+  (if (gethash key *api-registry*)
+      (progn
+        (setf *session* (make-instance 'session :key key))
+        (format t "[SECURE] Session Established. Tier: ~A~%" (auth-level *session*)))
+      (error "QUANTUM COLLAPSE: Unauthorized Key Intrusion.")))
 
-(defun recursive-cognitive-architecture (quantum-super-ai)
-  (setf (quantum-super-ai-learning-rate quantum-super-ai)
-        (* (quantum-super-ai-learning-rate quantum-super-ai) 0.99))
-  (incf (quantum-super-ai-iteration quantum-super-ai)))
+;; --- 4. ADVANCED MATHEMATICS & SUPERPOSITION ---
 
-(defun predictive-intelligence-framework (quantum-super-ai)
-  (let ((sum (reduce #'+ (quantum-super-ai-state-space quantum-super-ai))))
-    (* sum (+ 0.8 (random 0.4)))))
+(defun dot-product (v1 v2)
+  (loop for x in v1 for y in v2 sum (* x y)))
 
-(defun meta-intelligence-system (quantum-super-ai)
-  (let ((score (reduce #'+ (quantum-super-ai-state-space quantum-super-ai))))
-    (push score (quantum-super-ai-performance-log quantum-super-ai))
-    score))
+(defun magnitude (v)
+  (sqrt (loop for x in v sum (* x x))))
 
-(defun run-cycle (quantum-super-ai input-data)
-  (format t "~%=============================================")
-  (format t "~%  AI SYSTEM & FINANCIAL CYCLE START")
-  (format t "~%=============================================")
+(defun cosine-similarity (v1 v2)
+  (let ((mag (* (magnitude v1) (magnitude v2))))
+    (if (zerop mag) 0.0 (/ (dot-product v1 v2) mag))))
 
-  (format t "~%[COGNITION]")
-  (format t "~% -> ~a" (agi-core-system quantum-super-ai input-data))
+(defun softmax (vec)
+  (let* ((exps (mapcar #'exp vec))
+         (sum (reduce #'+ exps)))
+    (mapcar (lambda (x) (/ x sum)) exps)))
 
-  (let ((q-states (quantum-neural-system (quantum-super-ai-state-space quantum-super-ai))))
-    (format t "~% -> Quantum Decision Value: ~a" (round (quantum-ai q-states)))
-    (format t "~% -> Predictive State Forecast: ~a" (round (predictive-intelligence-framework quantum-super-ai))))
+(defun collapse-wave-function (base-signal entropy-level)
+  "Applies entropic jitter to simulate evaluating all market states simultaneously."
+  (mapcar (lambda (x)
+            (let ((jitter (* (- (random 2.0) 1.0) entropy-level)))
+              (max 0.0 (min 1.0 (+ x jitter)))))
+          base-signal))
 
-  (format t "~%~%[FINANCIAL NETWORK]")
-  (let ((swift-data (swift-federal-reserve-network quantum-super-ai)))
-    (format t "~% -> SWIFT Fed Balance:  ~a (~a)" (getf swift-data :balance) (getf swift-data :recent-yield))
-    (format t "~% -> SWIFT Routing:      ~a | ~a" (getf swift-data :routing-node) (getf swift-data :status)))
+;; --- 5. COGNITIVE ENGINE ---
 
-  (let ((crypto-data (crypto-wallet-manager quantum-super-ai)))
-    (format t "~% -> Crypto Wallet:      ~a...~a" (subseq (getf crypto-data :wallet-address) 0 12)
-            (subseq (getf crypto-data :wallet-address)
-                    (- (length (getf crypto-data :wallet-address)) 4)))
-    (format t "~% -> Crypto Balance:     ~a [Shift: ~a]" (getf crypto-data :balance-usd-value) (getf crypto-data :market-shift)))
+(defun retrieve-context (query-vec top-k)
+  (let ((scored-kb (mapcar (lambda (item)
+                             (append item (list :score (cosine-similarity (getf item :vector) query-vec))))
+                           (kb *core*))))
+    (subseq (sort scored-kb #'> :key (lambda (x) (getf x :score))) 0 (min top-k (length scored-kb)))))
 
-  (let ((card (generate-luhn-valid-card "4")))
-    (format t "~% -> Generated Auth Card: ~a (Luhn Valid)" card))
+(defun neural-forward-pass (input-vector weights)
+  (/ 1 (+ 1 (exp (- (loop for i in input-vector for w in weights sum (* i w)))))))
 
-  (quantum-learning-machine quantum-super-ai)
-  (recursive-cognitive-architecture quantum-super-ai)
-  (format t "~% -> Optimal Quantum State: ~,4f" (quantum-optimization quantum-super-ai))
-  (let ((score (meta-intelligence-system quantum-super-ai)))
-    (format t "~%~%[SYSTEM DIAGNOSTICS]")
-    (format t "~% -> Cycle Optimization Score: ~a" (round score)))
+(defun multi-agent-consensus (signal)
+  "Internal V3 consensus logic using the triplet agent heuristic."
+  (let* ((weights '((0.9 0.1 0.1) (0.1 0.9 0.1) (0.4 0.4 0.4)))
+         (votes (mapcar (lambda (w) (dot-product signal w)) weights)))
+    (softmax votes)))
 
-  (format t "~%=============================================~%"))
+(defun generate-omega-strategy (context)
+  (let ((top-concept (getf (first context) :concept))
+        (trust-score (cosine-similarity (getf (first context) :vector) '(1.0 1.0 1.0))))
+    (format nil "STRATEGY-OMEGA: ~A [Resonance: ~,2F%]"
+            (string-upcase top-concept) (* trust-score 100))))
 
-(let ((ai (make-quantum-super-ai)))
-  (dotimes (i 3)
-    (run-cycle ai (format nil "Executing Global Financial & Data Sweep #~d" (1+ i)))))
+(defun backpropagate (target-signal actual-output)
+  (let* ((error (- target-signal actual-output))
+         (lr (learning-rate *core*))
+         (new-weights (mapcar (lambda (w) (+ w (* lr error)))
+                              (neural-weights *core*))))
+    (setf (neural-weights *core*) new-weights)
+    (format t "[NEURAL] Synaptic weights adjusted. Delta: ~,4F~%" error)))
+
+;; --- 6. ENTROPIC EXECUTION LAYER ---
+
+(defun execute-quantum-trade (action base-amount confidence)
+  "Scales trade size dynamically based on market entropy (chaos)."
+  (unless *session* (error "Execution Denied: No Active Session."))
+  (let* ((current-entropy (entropy *market*))
+         (entropic-modifier (- 1.0 current-entropy))
+         (actual-amount (* base-amount confidence entropic-modifier))
+         (bal (balance *port*)))
+    (if (>= bal actual-amount)
+        (progn
+          (setf (balance *port*) (- bal actual-amount))
+          (format t "[LEDGER] ~A ~A units. Entropic Dampening: ~,2F~%"
+                  action (round actual-amount) entropic-modifier))
+        (format t "[LEDGER] Liquidity collapse. Cannot execute.~%"))))
+
+;; --- 7. MAIN RECURSIVE LOOP ---
+
+(defun run-quantum-cycle (api-key)
+  "The full loop: Sensing -> Collapse -> Reason -> Execute -> Learn"
+  (authenticate api-key)
+  (incf (epoch *core*))
+
+  (setf (entropy *market*) (random 0.4)) ;; Simulate market chaos
+
+  (format t "~%==================================================~%")
+  (format t ">>> EPOCH ~A | ENTROPY LEVEL: ~,3F <<<~%" (epoch *core*) (entropy *market*))
+  (format t "==================================================~%")
+
+  (let* ((raw-signal (list (random 1.0) (random 1.0) (random 1.0)))
+         ;; 1. Wave Function Collapse
+         (observed-signal (collapse-wave-function raw-signal (entropy *market*)))
+
+         ;; 2. Knowledge Retrieval
+         (context (retrieve-context observed-signal 3))
+         (strat-msg (generate-omega-strategy context))
+
+         ;; 3. Agent & Neural Inference
+         (agent-opinion (multi-agent-consensus observed-signal))
+         (inference (neural-forward-pass observed-signal (neural-weights *core*)))
+
+         ;; 4. Scoring logic
+         (final-score (* inference (reduce #'+ agent-opinion))))
+
+    (format t "[REASONING] ~A~%" strat-msg)
+    (format t "[SIGNAL] Inference Coherence: ~,4F~%" inference)
+
+    ;; 5. Decision & Execution
+    (cond ((> final-score 0.7)
+           (execute-quantum-trade 'LONG-STAKE 1.0e12 final-score))
+          ((< final-score 0.3)
+           (execute-quantum-trade 'SHORT-HEDGE 5.0e11 final-score))
+          (t (format t "[HOLD] Signal resonance insufficient (~,4F)~%" final-score)))
+
+    ;; 6. Backpropagation (Learning toward an idealized state)
+    (backpropagate 0.8 inference)))
+
+;; ======================================================================
+;; STARTUP SEQUENCE
+;; ======================================================================
+
+(initialize-system)
+
+(defparameter *v3-key* (generate-quantum-key "OVERLORD-01"))
+
+;; Running multiple cycles to observe the entropic scaling and weight adjustments
+(loop repeat 3 do (run-quantum-cycle *v3-key*))


### PR DESCRIPTION
### Motivation
- Introduce a CLOS-based V3 cognitive layer to replace the previous Lisp simulation with an entropic, wave-function collapse driven strategist for richer signal processing and execution behavior.
- Provide a reusable package interface (`initialize-system`, `generate-quantum-key`, `run-quantum-cycle`) to integrate the Lisp simulation with the rest of the playground.

### Description
- Replaced `quantum_ai.lisp` implementation with a new `:quantum-strat` package that defines CLOS classes `cognitive-core`, `portfolio`, `market-state`, and `session` and global state variables (`*core*`, `*port*`, `*market*`, `*session*`, `*api-registry*`).
- Implemented core utilities and algorithms including `collapse-wave-function`, `cosine-similarity`, `softmax`, `retrieve-context`, `neural-forward-pass`, `multi-agent-consensus`, `generate-omega-strategy`, `backpropagate`, and `execute-quantum-trade` as part of a full cognition->execute->learn loop in `run-quantum-cycle`.
- Added authentication and key registry via `generate-quantum-key` and `authenticate`, and a startup sequence that runs multiple cycles using `*v3-key*`.
- Updated `README.md` to reference the new `quantum-strat` package and V3 entropic strategist loop instead of the prior `quantum-super-ai` wording.

### Testing
- Ran the Python test suite with `pytest -q`, which completed successfully with `11 passed` tests.
- Attempted to run the Lisp script with `sbcl --script quantum_ai.lisp` but SBCL is not installed in the environment, so the Lisp runtime execution could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5c32e47c88327adfa048bb68768b3)