### PR TITLE
Add orchestration helper functions for agent lookup and confidence tracking

### DIFF
--- a/selfaware_ai_bank/bank_orchestrator.py
+++ b/selfaware_ai_bank/bank_orchestrator.py
@@ -100,5 +100,31 @@ class SelfAwareAIBank:
     def update_context(self, **kwargs: Any) -> None:
         self.context.update(kwargs)
 
+
+    def get_agent(self, name: str) -> Optional[BaseAgent]:
+        """Return the first registered agent matching ``name``."""
+        for agent in self.agents:
+            if agent.name == name:
+                return agent
+        return None
+
+    def recent_history(self, *, limit: int = 10, agent: Optional[str] = None) -> List[Dict[str, Any]]:
+        """Return recent run history, optionally filtered to one agent."""
+        entries = self.history
+        if agent is not None:
+            entries = [entry for entry in entries if entry.get("agent") == agent]
+        if limit <= 0:
+            return []
+        return entries[-limit:]
+
+    def confidence_trend(self) -> Dict[str, Optional[float]]:
+        """Compute first/latest confidence values and their delta."""
+        values = [entry["confidence"] for entry in self.history if "confidence" in entry]
+        if not values:
+            return {"first": None, "latest": None, "delta": None}
+        first = float(values[0])
+        latest = float(values[-1])
+        return {"first": first, "latest": latest, "delta": latest - first}
+
     def has_agent(self, agent_type: Type[BaseAgent]) -> bool:
         return any(isinstance(agent, agent_type) for agent in self.agents)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -9,7 +9,7 @@ class MockAgent(BaseAgent):
         super().__init__(name=name, category="Test", purpose="Testing")
 
     def execute(self, context):
-        return {"status": "success", "value": 42}
+        return {"status": "success", "value": 42, "confidence": 0.75}
 
 class TestBaseAgent(unittest.TestCase):
     def test_initialization(self):
@@ -22,7 +22,7 @@ class TestBaseAgent(unittest.TestCase):
     def test_execute(self):
         agent = MockAgent()
         result = agent.execute({})
-        self.assertEqual(result, {"status": "success", "value": 42})
+        self.assertEqual(result, {"status": "success", "value": 42, "confidence": 0.75})
 
     def test_update_state(self):
         agent = MockAgent()
@@ -63,6 +63,33 @@ class TestBankOrchestrator(unittest.TestCase):
         self.assertEqual(len(results), 2)
         self.assertEqual(results[0][0], "Agent1")
         self.assertEqual(results[1][0], "Agent2")
+
+
+    def test_get_agent_and_recent_history(self):
+        bank = SelfAwareAIBank()
+        agent1 = MockAgent(name="Agent1")
+        agent2 = MockAgent(name="Agent2")
+        bank.register_agents([agent1, agent2])
+
+        bank.run_all()
+
+        self.assertIs(bank.get_agent("Agent1"), agent1)
+        self.assertIsNone(bank.get_agent("Missing"))
+
+        self.assertEqual(len(bank.recent_history(limit=1)), 1)
+        self.assertEqual(len(bank.recent_history(limit=10, agent="Agent2")), 1)
+        self.assertEqual(bank.recent_history(limit=0), [])
+
+    def test_confidence_trend(self):
+        bank = SelfAwareAIBank()
+        agent = MockAgent()
+        bank.register_agent(agent)
+
+        bank.run_agent(agent)
+        self.assertEqual(bank.confidence_trend(), {"first": 0.75, "latest": 0.75, "delta": 0.0})
+
+        bank.history.append({"agent": "Manual", "confidence": 0.55})
+        self.assertEqual(bank.confidence_trend(), {"first": 0.75, "latest": 0.55, "delta": -0.19999999999999996})
 
     def test_summary(self):
         bank = SelfAwareAIBank()


### PR DESCRIPTION
### Motivation
- Provide lightweight utilities on the orchestrator to inspect registered agents and recent run history for easier introspection and debugging.
- Expose a simple confidence-trend computation to track signal quality across agent runs.

### Description
- Added `SelfAwareAIBank.get_agent(name)` to return the first registered agent matching the given name.
- Added `SelfAwareAIBank.recent_history(*, limit: int = 10, agent: Optional[str] = None)` to return recent run entries with optional agent filtering and safe handling of non-positive limits.
- Added `SelfAwareAIBank.confidence_trend()` to compute the first and latest confidence values and their delta from recorded history.
- Updated `tests/test_core.py` to include `confidence` in the `MockAgent` output and new tests `test_get_agent_and_recent_history` and `test_confidence_trend`; changes touch `selfaware_ai_bank/bank_orchestrator.py` and `tests/test_core.py`.

### Testing
- Ran the test suite with `pytest -q` and all automated tests passed (`13 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8400386a88327a2e0d57c7655f045)