### PR TITLE
Add reusable demo analytics helpers and coverage

### DIFF
--- a/main.py
+++ b/main.py
@@ -13,6 +13,27 @@ from selfaware_ai_bank.agents import CreditRiskAnalyzer, LiquidityOptimizer, Str
 from selfaware_ai_bank.cyber_os_v5 import MatrixServer, SYNONYM_GROUPS, SecureBankSystem, scan_network
 
 
+def calculate_total_liquidity(context: dict) -> float:
+    # Self-awareness: Aggregating liquidity to maintain a high-level health signal.
+    liquidity_levels = context.get("liquidity_levels", {})
+    return float(sum(liquidity_levels.values()))
+
+
+def identify_high_risk_exposures(context: dict, threshold: float) -> list[dict]:
+    # Self-awareness: Filtering exposures to focus attention on elevated portfolio risk.
+    exposures = context.get("credit_portfolio", [])
+    return [item for item in exposures if item.get("prob_default", 0.0) >= threshold]
+
+
+def summarize_trigger_signals(context: dict) -> dict[str, int]:
+    # Self-awareness: Counting operational signals to improve traceability in reports.
+    triggers = context.get("triggers", [])
+    summary: dict[str, int] = {}
+    for trigger in triggers:
+        summary[trigger] = summary.get(trigger, 0) + 1
+    return summary
+
+
 def build_demo_context() -> dict:
     # Self-awareness: Maintaining a transparent view of the sandbox data.
     return {
@@ -161,6 +182,14 @@ def main(argv: Optional[Iterable[str]] = None) -> None:
 
     summary = bank.summary()
     maybe_write_summary(args.summary_path, summary)
+
+    total_liquidity = calculate_total_liquidity(bank.context)
+    high_risk = identify_high_risk_exposures(bank.context, args.high_risk_threshold)
+    trigger_summary = summarize_trigger_signals(bank.context)
+
+    print(f"Total liquidity across currencies: {total_liquidity:,.0f}")
+    print(f"High-risk exposure count (threshold={args.high_risk_threshold}): {len(high_risk)}")
+    print(f"Trigger summary: {trigger_summary}\n")
 
     print("Introspection summary:")
     pprint(summary)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,28 @@
+import unittest
+
+from main import calculate_total_liquidity, identify_high_risk_exposures, summarize_trigger_signals
+
+
+class TestMainHelpers(unittest.TestCase):
+    def test_calculate_total_liquidity(self):
+        context = {"liquidity_levels": {"USD": 1500, "EUR": 2500, "JPY": 300}}
+        self.assertEqual(calculate_total_liquidity(context), 4300.0)
+
+    def test_identify_high_risk_exposures(self):
+        context = {
+            "credit_portfolio": [
+                {"name": "A", "prob_default": 0.02},
+                {"name": "B", "prob_default": 0.06},
+                {"name": "C", "prob_default": 0.1},
+            ]
+        }
+        result = identify_high_risk_exposures(context, threshold=0.05)
+        self.assertEqual([item["name"] for item in result], ["B", "C"])
+
+    def test_summarize_trigger_signals(self):
+        context = {"triggers": ["Fraud", "Liquidity", "Fraud"]}
+        self.assertEqual(summarize_trigger_signals(context), {"Fraud": 2, "Liquidity": 1})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Make demo reporting logic reusable and testable by extracting small analytics helpers from the CLI flow. 
- Surface concise runtime signals (liquidity total, high-risk exposure count, trigger rollups) to improve immediate visibility in the demo output. 

### Description
- Add `calculate_total_liquidity(context: dict) -> float` to aggregate `liquidity_levels` in `main.py`. 
- Add `identify_high_risk_exposures(context: dict, threshold: float) -> list[dict]` to filter `credit_portfolio` by `prob_default` in `main.py`. 
- Add `summarize_trigger_signals(context: dict) -> dict[str, int]` to count trigger occurrences in `main.py`. 
- Integrate the three helpers into the demo summary so `main()` prints total liquidity, high-risk exposure count (using `--high-risk-threshold`), and a trigger summary map. 
- Add unit tests in `tests/test_main.py` covering each helper function. 

### Testing
- Ran the test suite with `pytest -q` and observed all tests pass. 
- Total result: `14 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8401b93948327b617c35ebc21f906)