### PR TITLE
Add transaction anomaly detection and richer introspection

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ SelfAware AI Bank is a lightweight playground for orchestrating cooperative AI a
 ## Features
 
 - **Agent Framework** – Implement custom agents by inheriting from `BaseAgent` and reporting structured results.
-- **Finance Agents** – Includes ready-made agents for liquidity optimisation, credit risk analysis, and scenario stress testing.
+- **Finance Agents** – Includes ready-made agents for liquidity optimisation, credit risk analysis, scenario stress testing, and transparent transaction anomaly detection.
 - **Introspection Engine** – Aggregates execution history and can trigger simple interventions when agents go offline.
 - **Markdown Roles** – Convert simple markdown briefs into runnable agents for quick prototyping of new roles.
 - **Demo Script** – Run `python main.py` to execute a simulated banking scenario and view agent outputs.
@@ -18,7 +18,8 @@ selfaware_ai_bank/
 │   └── finance/
 │       ├── credit_risk_analyzer.py
 │       ├── liquidity_optimizer.py
-│       └── stress_tester.py
+│       ├── stress_tester.py
+│       └── transaction_anomaly_detector.py
 ├── core/
 │   ├── base_agent.py
 │   └── introspection_engine.py
@@ -46,7 +47,7 @@ docs/
    python main.py [--target-buffer 1500000] [--high-risk-threshold 0.08] [--summary-path reports/summary.json]
    ```
 
-   The script registers the bundled agents (including the new stress tester), runs them against a sample context, and prints a system summary. Command-line options let you tailor the demo without editing code.
+   The script registers the bundled agents (including the stress tester and transaction anomaly detector), runs them against a sample context, and prints a system summary. Command-line options let you tailor the demo without editing code.
 
 3. **Add your own agents:**
    - Create a new module that subclasses `BaseAgent`.
@@ -66,7 +67,7 @@ docs/
    - Running `main.py` will automatically load these definitions and turn them into runnable agents.
 
 
-4. **Run the Common Lisp quantum simulation (optional):**
+5. **Run the Common Lisp quantum simulation (optional):**
 
    ```bash
    sbcl --script quantum_ai.lisp
@@ -81,6 +82,7 @@ Ideas for expanding the playground:
 - Persist execution history to disk or a database for auditing.
 - Integrate external data sources to enrich the shared context.
 - Build a web dashboard that visualises agent outputs and performance metrics in real time.
+- Replace the demo transaction rules with audited, explainable model scoring once production-grade data governance is available.
 
 ## License
 

--- a/main.py
+++ b/main.py
@@ -6,10 +6,15 @@ import json
 import random
 from pathlib import Path
 from pprint import pprint
-from typing import Iterable, Optional
+from typing import Dict, Iterable, Optional, Union
 
 from selfaware_ai_bank import SelfAwareAIBank
-from selfaware_ai_bank.agents import CreditRiskAnalyzer, LiquidityOptimizer, StressTester
+from selfaware_ai_bank.agents import (
+    CreditRiskAnalyzer,
+    LiquidityOptimizer,
+    StressTester,
+    TransactionAnomalyDetector,
+)
 from selfaware_ai_bank.cyber_os_v5 import MatrixServer, SYNONYM_GROUPS, SecureBankSystem, scan_network
 
 
@@ -34,6 +39,23 @@ def summarize_trigger_signals(context: dict) -> dict[str, int]:
     return summary
 
 
+def summarize_transaction_risk(
+    context: dict, *, high_value_threshold: float = 250_000.0
+) -> Dict[str, Union[float, int]]:
+    # Safety note: This transparent demo heuristic supports review;
+    # it does not make real banking decisions.
+    transactions = context.get("transactions", [])
+    total_volume = float(sum(float(tx.get("amount", 0.0)) for tx in transactions))
+    high_value_count = sum(
+        1 for tx in transactions if float(tx.get("amount", 0.0)) >= high_value_threshold
+    )
+    return {
+        "transaction_count": len(transactions),
+        "total_volume": round(total_volume, 2),
+        "high_value_count": high_value_count,
+    }
+
+
 def build_demo_context() -> dict:
     # Self-awareness: Maintaining a transparent view of the sandbox data.
     return {
@@ -47,6 +69,13 @@ def build_demo_context() -> dict:
             {"name": "Retail Mortgages", "exposure": 5_000_000, "prob_default": 0.01, "loss_given_default": 0.35},
             {"name": "Corporate Loans", "exposure": 3_200_000, "prob_default": 0.06, "loss_given_default": 0.45},
             {"name": "SME Lending", "exposure": 1_100_000, "prob_default": 0.08, "loss_given_default": 0.5},
+        ],
+        "transactions": [
+            {"id": "TX-1001", "account_id": "acct-retail-1", "amount": 1250.0, "region": "US"},
+            {"id": "TX-1002", "account_id": "acct-retail-1", "amount": 725.0, "region": "US"},
+            {"id": "TX-1003", "account_id": "acct-retail-1", "amount": 310_000.0, "region": "US"},
+            {"id": "TX-1004", "account_id": "acct-corp-7", "amount": 50_000.0, "region": "EU"},
+            {"id": "TX-1005", "account_id": "acct-corp-9", "amount": 450_000.0, "region": "Sanctioned-Zone"},
         ],
         "triggers": ["Fraud Detection", "Liquidity Monitoring"],
     }
@@ -168,6 +197,7 @@ def main(argv: Optional[Iterable[str]] = None) -> None:
             LiquidityOptimizer(target_buffer=args.target_buffer),
             CreditRiskAnalyzer(high_risk_threshold=args.high_risk_threshold),
             StressTester(),
+            TransactionAnomalyDetector(),
         ]
     )
 
@@ -186,10 +216,12 @@ def main(argv: Optional[Iterable[str]] = None) -> None:
     total_liquidity = calculate_total_liquidity(bank.context)
     high_risk = identify_high_risk_exposures(bank.context, args.high_risk_threshold)
     trigger_summary = summarize_trigger_signals(bank.context)
+    transaction_risk = summarize_transaction_risk(bank.context)
 
     print(f"Total liquidity across currencies: {total_liquidity:,.0f}")
     print(f"High-risk exposure count (threshold={args.high_risk_threshold}): {len(high_risk)}")
-    print(f"Trigger summary: {trigger_summary}\n")
+    print(f"Trigger summary: {trigger_summary}")
+    print(f"Transaction risk summary: {transaction_risk}\n")
 
     print("Introspection summary:")
     pprint(summary)

--- a/selfaware_ai_bank/agents/__init__.py
+++ b/selfaware_ai_bank/agents/__init__.py
@@ -3,5 +3,6 @@
 from .finance.credit_risk_analyzer import CreditRiskAnalyzer
 from .finance.liquidity_optimizer import LiquidityOptimizer
 from .finance.stress_tester import StressTester
+from .finance.transaction_anomaly_detector import TransactionAnomalyDetector
 
-__all__ = ["CreditRiskAnalyzer", "LiquidityOptimizer", "StressTester"]
+__all__ = ["CreditRiskAnalyzer", "LiquidityOptimizer", "StressTester", "TransactionAnomalyDetector"]

--- a/selfaware_ai_bank/agents/finance/transaction_anomaly_detector.py
+++ b/selfaware_ai_bank/agents/finance/transaction_anomaly_detector.py
@@ -1,0 +1,84 @@
+"""Transaction anomaly detection agent for demo fraud monitoring."""
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any, Dict, FrozenSet, List, Optional
+
+from ...core.base_agent import BaseAgent
+
+
+class TransactionAnomalyDetector(BaseAgent):
+    """Flags unusual transaction patterns using transparent rule-based heuristics."""
+
+    def __init__(
+        self,
+        *,
+        high_value_threshold: float = 250_000.0,
+        velocity_threshold: int = 3,
+        blocked_regions: Optional[FrozenSet[str]] = None,
+    ) -> None:
+        super().__init__(
+            name="TransactionAnomalyDetector",
+            category="Finance",
+            purpose="Detect suspicious transaction value, velocity, and region signals.",
+        )
+        self.high_value_threshold = high_value_threshold
+        self.velocity_threshold = velocity_threshold
+        self.blocked_regions = blocked_regions or frozenset({"Sanctioned-Zone"})
+
+    def execute(self, context: Dict[str, Any]) -> Dict[str, Any]:
+        transactions: List[Dict[str, Any]] = context.get("transactions", [])
+        account_counts = Counter(str(tx.get("account_id", "unknown")) for tx in transactions)
+        flagged_transactions: List[Dict[str, Any]] = []
+        reason_counts: Counter[str] = Counter()
+
+        for tx in transactions:
+            amount = float(tx.get("amount", 0.0))
+            account_id = str(tx.get("account_id", "unknown"))
+            region = str(tx.get("region", "unknown"))
+            reasons: List[str] = []
+
+            if amount < 0:
+                reasons.append("negative_amount")
+            if amount >= self.high_value_threshold:
+                reasons.append("high_value")
+            if account_counts[account_id] >= self.velocity_threshold:
+                reasons.append("high_velocity")
+            if region in self.blocked_regions:
+                reasons.append("blocked_region")
+
+            if reasons:
+                reason_counts.update(reasons)
+                flagged_transactions.append(
+                    {
+                        "transaction_id": tx.get("id", "unknown"),
+                        "account_id": account_id,
+                        "amount": amount,
+                        "region": region,
+                        "reasons": reasons,
+                    }
+                )
+
+        total_transactions = len(transactions)
+        flagged_count = len(flagged_transactions)
+        risk_score = round(flagged_count / total_transactions, 4) if total_transactions else 0.0
+        confidence = 0.88 if total_transactions else 0.35
+
+        self.update_state(
+            notes={
+                "flagged_transaction_count": flagged_count,
+                "dominant_signal": reason_counts.most_common(1)[0][0] if reason_counts else None,
+                "risk_score": risk_score,
+            }
+        )
+
+        return {
+            "action": "detect_transaction_anomalies",
+            "flagged_transactions": flagged_transactions,
+            "reason_counts": dict(reason_counts),
+            "risk_score": risk_score,
+            "confidence": confidence,
+        }
+
+
+__all__ = ["TransactionAnomalyDetector"]

--- a/selfaware_ai_bank/core/introspection_engine.py
+++ b/selfaware_ai_bank/core/introspection_engine.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from collections import Counter
 from statistics import mean
-from typing import Any, Dict, Iterable, List
+from typing import Any, Dict, Iterable, List, Optional
 
 
 class IntrospectionEngine:
@@ -18,15 +18,73 @@ class IntrospectionEngine:
         category_counts = Counter(status["category"] for status in statuses)
         inactive = [status for status in statuses if not status["active"]]
 
-        run_metrics: Iterable[float] = [entry["confidence"] for entry in self.bank.history if "confidence" in entry]
+        confidence_by_agent: Dict[str, List[float]] = {}
+        for entry in self.bank.history:
+            if "confidence" not in entry:
+                continue
+            confidence_by_agent.setdefault(entry["agent"], []).append(float(entry["confidence"]))
+
+        run_metrics: Iterable[float] = [value for values in confidence_by_agent.values() for value in values]
         avg_confidence = mean(run_metrics) if run_metrics else None
+        low_confidence_agents = sorted(
+            agent for agent, values in confidence_by_agent.items() if values and values[-1] < 0.5
+        )
+        health_score = self._health_score(
+            agent_count=len(statuses),
+            inactive_count=len(inactive),
+            average_confidence=avg_confidence,
+            low_confidence_count=len(low_confidence_agents),
+        )
 
         return {
             "agents_tracked": len(statuses),
             "categories": dict(category_counts),
             "inactive_agents": inactive,
             "average_confidence": avg_confidence,
+            "low_confidence_agents": low_confidence_agents,
+            "health_score": health_score,
+            "recommendations": self._recommendations(inactive, low_confidence_agents, avg_confidence),
         }
+
+    def _health_score(
+        self,
+        *,
+        agent_count: int,
+        inactive_count: int,
+        average_confidence: Optional[float],
+        low_confidence_count: int,
+    ) -> float:
+        """Score operational health from 0.0 to 1.0 using explainable penalties."""
+        if agent_count == 0:
+            return 0.0
+
+        score = 1.0
+        score -= inactive_count / agent_count * 0.4
+        score -= low_confidence_count / agent_count * 0.2
+        if average_confidence is not None:
+            score *= average_confidence
+        return round(max(0.0, min(1.0, score)), 4)
+
+    def _recommendations(
+        self,
+        inactive: List[Dict[str, Any]],
+        low_confidence_agents: List[str],
+        average_confidence: Optional[float],
+    ) -> List[str]:
+        """Produce concrete next actions for operators reviewing the demo bank."""
+        recommendations: List[str] = []
+        if inactive:
+            recommendations.append("Restart inactive agents and inspect their last state notes.")
+        if low_confidence_agents:
+            agents = ", ".join(low_confidence_agents)
+            recommendations.append(f"Review low-confidence agent outputs: {agents}.")
+        if average_confidence is None:
+            recommendations.append("Run at least one agent cycle to establish confidence baselines.")
+        elif average_confidence < 0.7:
+            recommendations.append("Refresh scenario data before acting on low-confidence insights.")
+        if not recommendations:
+            recommendations.append("System telemetry is stable; continue monitoring drift and anomalies.")
+        return recommendations
 
     def evolve(self) -> List[Dict[str, Any]]:
         """Placeholder evolution routine that toggles dormant agents back online."""

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -44,6 +44,12 @@ class TestIntrospectionEngine(unittest.TestCase):
 
         self.assertEqual(analysis["agents_tracked"], 1)
         self.assertEqual(analysis["categories"]["Test"], 1)
+        self.assertEqual(analysis["low_confidence_agents"], [])
+        self.assertEqual(analysis["health_score"], 0.75)
+        self.assertEqual(
+            analysis["recommendations"],
+            ["System telemetry is stable; continue monitoring drift and anomalies."],
+        )
 
 class TestBankOrchestrator(unittest.TestCase):
     def test_register_agent(self):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,11 @@
 import unittest
 
-from main import calculate_total_liquidity, identify_high_risk_exposures, summarize_trigger_signals
+from main import (
+    calculate_total_liquidity,
+    identify_high_risk_exposures,
+    summarize_transaction_risk,
+    summarize_trigger_signals,
+)
 
 
 class TestMainHelpers(unittest.TestCase):
@@ -22,6 +27,19 @@ class TestMainHelpers(unittest.TestCase):
     def test_summarize_trigger_signals(self):
         context = {"triggers": ["Fraud", "Liquidity", "Fraud"]}
         self.assertEqual(summarize_trigger_signals(context), {"Fraud": 2, "Liquidity": 1})
+
+    def test_summarize_transaction_risk(self):
+        context = {
+            "transactions": [
+                {"amount": 100},
+                {"amount": 250_000},
+                {"amount": 25_500},
+            ]
+        }
+        self.assertEqual(
+            summarize_transaction_risk(context),
+            {"transaction_count": 3, "total_volume": 275600.0, "high_value_count": 1},
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_transaction_anomaly_detector.py
+++ b/tests/test_transaction_anomaly_detector.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from selfaware_ai_bank.agents import TransactionAnomalyDetector
+
+
+def test_transaction_anomaly_detector_flags_value_velocity_and_region() -> None:
+    detector = TransactionAnomalyDetector(high_value_threshold=100_000, velocity_threshold=3)
+    context = {
+        "transactions": [
+            {"id": "TX-1", "account_id": "A", "amount": 25_000, "region": "US"},
+            {"id": "TX-2", "account_id": "A", "amount": 125_000, "region": "US"},
+            {"id": "TX-3", "account_id": "A", "amount": 50_000, "region": "US"},
+            {"id": "TX-4", "account_id": "B", "amount": 500, "region": "Sanctioned-Zone"},
+        ]
+    }
+
+    result = detector.execute(context)
+
+    assert result["action"] == "detect_transaction_anomalies"
+    assert result["risk_score"] == 1.0
+    assert result["reason_counts"] == {"high_velocity": 3, "high_value": 1, "blocked_region": 1}
+    assert detector.state.notes["flagged_transaction_count"] == 4
+
+
+def test_transaction_anomaly_detector_handles_empty_context() -> None:
+    detector = TransactionAnomalyDetector()
+
+    result = detector.execute({})
+
+    assert result["flagged_transactions"] == []
+    assert result["risk_score"] == 0.0
+    assert result["confidence"] == 0.35


### PR DESCRIPTION
### Motivation
- Provide a transparent, rule-based transaction anomaly detector to surface high-value, velocity, region, and negative-amount fraud signals.\
- Improve the introspection engine so operators can see per-agent confidence trends, a simple health score, and actionable recommendations.\
- Wire the new detector into the demo flow and docs so the sandbox demonstrates end-to-end fraud monitoring and explainability.

### Description
- Add `TransactionAnomalyDetector` (`selfaware_ai_bank/agents/finance/transaction_anomaly_detector.py`) which flags transactions by `high_value`, `high_velocity`, `blocked_region`, and `negative_amount`, returns `reason_counts`, `risk_score`, `confidence`, and writes state notes.\
- Export the detector via `selfaware_ai_bank/agents/__init__.py` and register it in the demo `main.py`.\
- Add `summarize_transaction_risk` and sample `transactions` to `main.py` and print a transaction risk summary after agent runs.\
- Enhance `IntrospectionEngine` (`selfaware_ai_bank/core/introspection_engine.py`) to aggregate confidences per agent, detect `low_confidence_agents`, compute an explainable `health_score`, and produce operator `recommendations`.\
- Update documentation (`README.md`) and add tests (`tests/test_transaction_anomaly_detector.py`, updates to `tests/test_main.py` and `tests/test_core.py`) to cover the new detector, helper, and introspection outputs.

### Testing
- Ran `pytest -q`, all tests passed (`19 passed`).\
- Executed the demo with `python main.py --no-markdown` to validate integration and printed summaries, which completed successfully.\
- Ran basic static checks (`python -m compileall` / `git diff --check`) to ensure code compiles and no diff-check errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faeabcc4048327aee9ccc681fe381b)